### PR TITLE
TabContainer example fixes

### DIFF
--- a/client-app/src/desktop/tabs/containers/TabPanelContainerPanel.js
+++ b/client-app/src/desktop/tabs/containers/TabPanelContainerPanel.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {HoistComponent} from '@xh/hoist/core';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {hspacer} from '@xh/hoist/cmp/layout';
 import {tabContainer, TabContainerModel} from '@xh/hoist/desktop/cmp/tab';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {button} from '@xh/hoist/desktop/cmp/button';
@@ -94,8 +95,7 @@ export class TabPanelContainerPanel extends Component {
                                 title: 'Tab State',
                                 content: () => {
                                     const peopleTab = stateTabModel.getTabById('people'),
-                                        placesTab = stateTabModel.getTabById('places'),
-                                        thingsTab = stateTabModel.getTabById('things');
+                                        placesTab = stateTabModel.getTabById('places')
 
                                     return panel({
                                         className: 'child-tabcontainer',
@@ -105,14 +105,11 @@ export class TabPanelContainerPanel extends Component {
                                                 field: 'disabled',
                                                 label: 'People Disabled?'
                                             }),
+                                            hspacer(10),
+                                            'Places Tab Title: ',
                                             textInput({
                                                 model: placesTab,
                                                 field: 'title'
-                                            }),
-                                            switchInput({
-                                                model: thingsTab,
-                                                field: 'excludeFromSwitcher',
-                                                label: 'Things Hidden?'
                                             })
                                         ),
                                         item: tabContainer({model: stateTabModel})

--- a/client-app/src/desktop/tabs/containers/TabPanelContainerPanel.js
+++ b/client-app/src/desktop/tabs/containers/TabPanelContainerPanel.js
@@ -6,13 +6,15 @@ import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {wrapper} from '../../common/Wrapper';
+import {switchInput, textInput} from '@xh/hoist/desktop/cmp/form';
 
 @HoistComponent
 export class TabPanelContainerPanel extends Component {
-    topModel =  this.createTopModel()
+    detachedTabModel = new TabContainerModel(this.createContainerModelConfig());
+    stateTabModel = new TabContainerModel(this.createContainerModelConfig());
 
     render() {
-        const {topModel} = this;
+        const {detachedTabModel, stateTabModel} = this;
 
         return wrapper({
             description: [
@@ -32,90 +34,106 @@ export class TabPanelContainerPanel extends Component {
                 className: 'toolbox-containers-tabs',
                 width: 700,
                 height: 400,
-                item: tabContainer({model: topModel})
+                item: tabContainer({
+                    model: {
+                        tabs: [
+                            {
+                                id: 'top',
+                                title: 'Top Tabs',
+                                content: () => `
+                        This overall example is a standard TabContainer with its switcher located in the default,
+                        top position. Change the tabs above to see examples of other TabContainer configurations.
+                    `
+                            },
+                            {
+                                id: 'bottom',
+                                title: 'Bottom Tabs',
+                                content: () => tabContainer({
+                                    className: 'child-tabcontainer',
+                                    model: this.createContainerModelConfig(),
+                                    switcherPosition: 'bottom'
+                                })
+                            },
+                            {
+                                id: 'left',
+                                title: 'Left Tabs',
+                                content: () => tabContainer({
+                                    className: 'child-tabcontainer',
+                                    model: this.createContainerModelConfig(),
+                                    switcherPosition: 'left'
+                                })
+                            },
+                            {
+                                id: 'right',
+                                title: 'Right Tabs',
+                                content: () => tabContainer({
+                                    className: 'child-tabcontainer',
+                                    model: this.createContainerModelConfig(),
+                                    switcherPosition: 'right'
+                                })
+                            },
+                            {
+                                id: 'custom',
+                                title: 'Custom Switcher',
+                                content: () => panel({
+                                    className: 'child-tabcontainer',
+                                    tbar: toolbar(
+                                        detachedTabModel.tabs.map(childModel => button({
+                                            intent: childModel.isActive ? 'primary' : 'default',
+                                            text: childModel.title,
+                                            onClick: () => {
+                                                detachedTabModel.setActiveTabId(childModel.id);
+                                            }
+                                        }))
+                                    ),
+                                    item: tabContainer({model: detachedTabModel, switcherPosition: 'none'})
+                                })
+                            },
+                            {
+                                id: 'state',
+                                title: 'Tab State',
+                                content: () => {
+                                    const peopleTab = stateTabModel.getTabById('people'),
+                                        placesTab = stateTabModel.getTabById('places'),
+                                        thingsTab = stateTabModel.getTabById('things');
+
+                                    return panel({
+                                        className: 'child-tabcontainer',
+                                        bbar: toolbar(
+                                            switchInput({
+                                                model: peopleTab,
+                                                field: 'disabled',
+                                                label: 'People Disabled?'
+                                            }),
+                                            textInput({
+                                                model: placesTab,
+                                                field: 'title'
+                                            }),
+                                            switchInput({
+                                                model: thingsTab,
+                                                field: 'excludeFromSwitcher',
+                                                label: 'Things Hidden?'
+                                            })
+                                        ),
+                                        item: tabContainer({model: stateTabModel})
+                                    });
+                                }
+                            }
+                        ]
+                    }
+                })
             })
         });
     }
 
-    createTopModel() {
-        const detachedModel = this.createContainerModel();
-
-        const intro = `
-            This overall example is a standard TabContainer with its switcher located in the default,
-            top position. Change the tabs above to see examples of other TabContainer configurations.
-        `;
-
-        return new TabContainerModel({
-            tabs: [
-                {
-                    id: 'top',
-                    title: 'Top Tabs',
-                    content: () => intro
-                },
-                {
-                    id: 'bottom',
-                    title: 'Bottom Tabs',
-                    content: () => {
-                        return tabContainer({
-                            className: 'child-tabcontainer',
-                            model: this.createContainerModel(),
-                            switcherPosition: 'bottom'
-                        });
-                    }
-                },
-                {
-                    id: 'left',
-                    title: 'Left Tabs',
-                    content: () => {
-                        return tabContainer({
-                            className: 'child-tabcontainer',
-                            model: this.createContainerModel(),
-                            switcherPosition: 'left'
-                        });
-                    }
-                },
-                {
-                    id: 'right',
-                    title: 'Right Tabs',
-                    content: () => {
-                        return tabContainer({
-                            className: 'child-tabcontainer',
-                            model: this.createContainerModel(),
-                            switcherPosition: 'right'
-                        });
-                    }
-                },
-                {
-                    id: 'custom',
-                    title: 'Custom Switcher',
-                    content: () => {
-                        return panel({
-                            className: 'child-tabcontainer',
-                            tbar: toolbar(
-                                detachedModel.tabs.map(childModel => button({
-                                    intent: childModel.isActive ? 'primary' : 'default',
-                                    text: childModel.title,
-                                    onClick: () => {
-                                        detachedModel.setActiveTabId(childModel.id);
-                                    }
-                                }))
-                            ),
-                            item: tabContainer({model: detachedModel, switcherPosition: 'none'})
-                        });
-                    }
-                }
-            ]
-        });
-    }
-
-    createContainerModel() {
+    createContainerModelConfig() {
         const tabTxt = title => `This is the ${title} tab`;
-        return new TabContainerModel({
+        return {
             tabs: [
                 {id: 'people', content: () => tabTxt('People')},
                 {id: 'places', content: () => tabTxt('Places')},
                 {id: 'things', content: () => tabTxt('Things')}
             ]
-        });
+        };
     }
 }


### PR DESCRIPTION
Fixed some errors when switching between tabs in the tab container example panel from the recent model changes 

Added example for the new tab state properties