### PR TITLE
Enabled exporting in several charts.

### DIFF
--- a/client-app/src/desktop/tabs/charts/LineChartModel.js
+++ b/client-app/src/desktop/tabs/charts/LineChartModel.js
@@ -91,6 +91,9 @@ export class LineChartModel {
                     },
                     threshold: null
                 }
+            },
+            exporting: {
+                enabled: true
             }
         };
     }

--- a/client-app/src/desktop/tabs/examples/portfolio/LineChartModel.js
+++ b/client-app/src/desktop/tabs/examples/portfolio/LineChartModel.js
@@ -60,6 +60,9 @@ export class LineChartModel {
                     },
                     threshold: null
                 }
+            },
+            exporting: {
+                enabled: true
             }
         }
     });

--- a/client-app/src/desktop/tabs/examples/portfolio/OHLCChartModel.js
+++ b/client-app/src/desktop/tabs/examples/portfolio/OHLCChartModel.js
@@ -60,6 +60,9 @@ export class OHLCChartModel {
                         </table>
                     `;
                 }
+            },
+            exporting: {
+                enabled: true
             }
         }
     });

--- a/client-app/yarn.lock
+++ b/client-app/yarn.lock
@@ -1004,9 +1004,10 @@
     webpack-dev-server "~3.1.10"
     webpackbar "~3.1.3"
 
-"@xh/hoist@^17.0.0-SNAPSHOT":
-  version "17.0.0-SNAPSHOT.1545059460647"
-  resolved "https://registry.yarnpkg.com/@xh/hoist/-/hoist-17.0.0-SNAPSHOT.1545059460647.tgz#7eee762dd745da7528245d4943ab7ab24cdf75d1"
+"@xh/hoist@^18.0.0-SNAPSHOT":
+  version "18.0.0-SNAPSHOT.1545244535405"
+  resolved "https://registry.yarnpkg.com/@xh/hoist/-/hoist-18.0.0-SNAPSHOT.1545244535405.tgz#99d64b3cff9f7a5768279a54c52fae6270bb19c3"
+  integrity sha512-eXyRvUlM27a/PXJpI1oAuvudgVfWmmF6hKeV/qh7RusO5laxpfl+5L3jOO07w7nfW/e5ix1AVMx5kpcfJbRWIA==
   dependencies:
     "@blueprintjs/core" "~3.10.0"
     "@blueprintjs/datetime" "~3.5.0"
@@ -1027,7 +1028,7 @@
     lodash-inflection "~1.5.0"
     mobx "~5.8.0"
     mobx-react "~5.4.3"
-    moment "~2.22.1"
+    moment "~2.23.0"
     numbro "~2.1.1"
     onsenui "~2.10.6"
     prop-types "~15.6.2"
@@ -1035,7 +1036,7 @@
     react-onsenui "~1.11.0"
     react-select "~2.1.1"
     react-transition-group "~2.5.1"
-    router5 "~6.6.2"
+    router5 "~6.6.3"
     rsvp "~4.8.4"
     store2 "~2.7.0"
 
@@ -4684,9 +4685,10 @@ mobx@~5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.8.0.tgz#cf59eae4baa2fde4387ffb6462b7ccf3b497b03c"
 
-moment@~2.22.1:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+moment@~2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
+  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6092,9 +6094,10 @@ router5-transition-path@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/router5-transition-path/-/router5-transition-path-5.4.0.tgz#8913c88a623a951a61c4e6eb32762a7218e5c7b1"
 
-router5@~6.6.2:
+router5@~6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/router5/-/router5-6.6.3.tgz#943a9d2fd23aaa4fbea3a6795f0acc40a0267328"
+  integrity sha512-tOyWFzg2FmIV2S/wcFFYvTau1jXXhZeVKYpE24WJAQ2vnA6PojyyNy2RTTKiPZz1w6XGf8taByBukQuImJhjBQ==
   dependencies:
     route-node "3.4.2"
     router5-transition-path "5.4.0"


### PR DESCRIPTION
Goes with hoist-react PR: https://github.com/exhi/hoist-react/pull/885, 
in which:
highcharts was updated to v7.0.1
 exporting was fixed