### PR TITLE
Hoist Dialog Component

### DIFF
--- a/client-app/src/desktop/AppModel.js
+++ b/client-app/src/desktop/AppModel.js
@@ -58,6 +58,7 @@ export class AppModel {
                         children: [
                             {name: 'hbox', path: '/hbox'},
                             {name: 'vbox', path: '/vbox'},
+                            {name: 'modal', path: '/modal'},
                             {name: 'panel', path: '/panel'},
                             {name: 'tabPanel', path: '/tabPanel'},
                             {name: 'toolbar', path: '/toolbar'}

--- a/client-app/src/desktop/tabs/containers/ContainersTab.js
+++ b/client-app/src/desktop/tabs/containers/ContainersTab.js
@@ -7,8 +7,10 @@ import {VBoxContainerPanel} from './VBoxContainerPanel';
 import {PanelContainerPanel} from './PanelContainerPanel';
 import {TabPanelContainerPanel} from './TabPanelContainerPanel';
 import {ToolbarPanel} from './ToolbarPanel';
+import { ModalPanel } from './ModalPanel';
 
 import './ContainersTab.scss';
+
 
 @HoistComponent
 export class ContainersTab extends Component {
@@ -19,6 +21,7 @@ export class ContainersTab extends Component {
                 tabs: [
                     {id: 'hbox', title: 'HBox', content: HBoxContainerPanel},
                     {id: 'vbox', title: 'VBox', content: VBoxContainerPanel},
+                    {id: 'modal', title: 'Modal', content: ModalPanel},
                     {id: 'panel', content: PanelContainerPanel},
                     {id: 'tabPanel', title: 'TabContainer', content: TabPanelContainerPanel},
                     {id: 'toolbar', content: ToolbarPanel}

--- a/client-app/src/desktop/tabs/containers/ModalPanel.js
+++ b/client-app/src/desktop/tabs/containers/ModalPanel.js
@@ -1,0 +1,91 @@
+import { Component } from 'react';
+
+import { XH, HoistComponent } from '@xh/hoist/core/index';
+import { filler, frame} from '@xh/hoist/cmp/layout';
+import { panel } from '@xh/hoist/desktop/cmp/panel';
+import { dialog } from '@xh/hoist/desktop/cmp/dialog';
+import { switchInput } from '@xh/hoist/desktop/cmp/input';
+import { toolbar } from '@xh/hoist/desktop/cmp/toolbar';
+import { button } from '@xh/hoist/desktop/cmp/button';
+import { Icon } from '@xh/hoist/icon';
+
+import { wrapper } from '../../common/Wrapper';
+import { ModalPanelModel } from './ModalPanelModel';
+
+@HoistComponent
+export class ModalPanel extends Component {
+    model = new ModalPanelModel();
+
+    render() {
+        const {model} = this,
+            {dialogModel} = model;
+
+        return wrapper({
+            description: `
+                Modals....
+            `,
+            item: panel({
+                title: 'Containers > Modal',
+                height: 400,
+                width: 700,
+                tbar: toolbar(
+                    button({
+                        icon: Icon.comment(),
+                        text: 'Dialog',
+                        intent: 'success',
+                        onClick: () => dialogModel.open()
+                    })
+                ),
+                bbar: toolbar({
+                    items: [
+                        switchInput({
+                            model: model,
+                            bind: 'isAnimated',
+                            label: 'Animate:',
+                            labelAlign: 'left'
+                        })
+                    ]
+                }),
+                items: [
+                    frame({
+                        padding: 10,
+                        item: 'Modal demos...'
+                    }),
+                    dialogModel.isOpen ? dialog({
+                        title: 'Demo Dialog',
+                        icon: Icon.handshake(),
+                        model: dialogModel,
+                        buttonBar: [
+                            filler(),
+                            button({
+                                text: 'Cancel',
+                                intent: 'primary',
+                                onClick: () => this.onCancelClick()
+                            }),
+                            button({
+                                text: 'Save',
+                                intent: 'success',
+                                onClick: () => this.onSaveClick()
+                            })
+                        ],
+                        item: 'Hello World'
+                    }) : null
+                ]
+            })
+        });
+    }
+
+    onCloseClick() {
+        this.model.dialogModel.close();
+    }
+
+    onCancelClick() {
+        XH.toast({message: 'Dialog canceled.'}),
+        this.model.dialogModel.close();
+    }
+
+    onSaveClick() {
+        XH.toast({message: 'Dialog saved.'}),
+        this.model.dialogModel.close();
+    }
+}

--- a/client-app/src/desktop/tabs/containers/ModalPanelModel.js
+++ b/client-app/src/desktop/tabs/containers/ModalPanelModel.js
@@ -1,0 +1,16 @@
+import {HoistModel} from '@xh/hoist/core/index';
+import {action, observable} from '@xh/hoist/mobx/index';
+import { DialogModel } from '@xh/hoist/desktop/cmp/dialog';
+
+@HoistModel
+export class ModalPanelModel {
+    @observable isAnimated = false;
+    @action
+    setIsAnimated() {
+        this.isAnimated = !this.isAnimated;
+        this.dialogModel = new DialogModel({isAnimated: this.isAnimated});
+    }
+
+    @observable
+    dialogModel = new DialogModel({isAnimated: this.isAnimated})
+}

--- a/client-app/src/desktop/tabs/other/MaskPanel.js
+++ b/client-app/src/desktop/tabs/other/MaskPanel.js
@@ -22,6 +22,7 @@ export class MaskPanel extends Component {
     @bindable message = '';
     @bindable inline = true;
     @bindable spinner = true;
+    @bindable isAnimated = false;
 
     maskModel = new PendingTaskModel();
 
@@ -81,6 +82,13 @@ export class MaskPanel extends Component {
                             label: 'Spinner:',
                             labelAlign: 'left'
                         }),
+                        toolbarSep(),
+                        switchInput({
+                            model: this,
+                            bind: 'isAnimated',
+                            label: 'Animate:',
+                            labelAlign: 'left'
+                        }),
                         filler(),
                         button({
                             text: 'Show Mask',
@@ -90,6 +98,7 @@ export class MaskPanel extends Component {
                     ]
                 }),
                 mask: mask({
+                    isAnimated: this.isAnimated,
                     spinner: this.spinner,
                     inline: this.inline,
                     model: this.maskModel


### PR DESCRIPTION
This noAnimations branch has new code that demos:
the new isAnimated prop on the mask component
the new Dialog component that wraps the BlueprintJS dialog, with animations off by default.

The Dialog component is WIP, and so is the the new Modal panel that demos it.  We plan to add demos of the other modals to the Modal panel:  message, alert, confirm.

This PR goes with hoist-react PR:  [#982](https://github.com/exhi/hoist-react/pull/982)
and with hoist-react branch [noAnimations](https://github.com/exhi/hoist-react/tree/noAnimations).