### PR TITLE
Improvements to portfolio and cube examples

### DIFF
--- a/client-app/src/core/svc/PortfolioService.js
+++ b/client-app/src/core/svc/PortfolioService.js
@@ -151,7 +151,7 @@ export class PortfolioService {
                     confidence: random(0, 1000)
                 });
             },
-            {tag: 'Generate orders'}
+            {debug: 'Generate orders'}
         );
 
         return sortBy(orders, [it => it.time]);
@@ -207,7 +207,7 @@ export class PortfolioService {
                     });
                 }
             },
-            {tag: 'Populate market data'}
+            {debug: 'Populate market data'}
         );
     }
 

--- a/client-app/src/desktop/tabs/examples/portfolio/OrdersPanel.js
+++ b/client-app/src/desktop/tabs/examples/portfolio/OrdersPanel.js
@@ -25,7 +25,7 @@ export class OrdersPanel extends Component {
             title: 'Orders',
             icon: Icon.edit(),
             item: grid({model: gridModel}),
-            mask: model.loadModel,
+            mask: model.positionId == null,
             bbar: toolbar(
                 filler(),
                 storeCountLabel({gridModel, unit: 'orders'}),

--- a/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
+++ b/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
@@ -23,6 +23,9 @@ export class CubeDataModel {
     @bindable orderCount = XH.getPref('cubeTestOrderCount');
     @bindable fundFilter = null;
 
+    // Flag to short-circuit initial/duplicate firing of query reaction (below).
+    _initialLoadComplete = false;
+
     constructor() {
         this.gridModel = this.createGridModel();
         this.loadTimesGridModel = this.createLoadTimesGridModel();
@@ -40,7 +43,11 @@ export class CubeDataModel {
 
         this.addReaction({
             track: () => this.getQuery(),
-            run: (q) => this.executeQueryAsync(),
+            run: () => {
+                if (this._initialLoadComplete) {
+                    this.executeQueryAsync();
+                }
+            },
             equals: comparer.structural
         });
 
@@ -70,8 +77,7 @@ export class CubeDataModel {
             ocTxt = fmtThousands(this.orderCount) + 'k';
 
         await this.withLoadTime(`Gen ${ocTxt} orders`, async () => {
-            // TODO - generate orders in non-blocking/async loop.
-            orders = XH.portfolioService.generateOrders(this.orderCount);
+            orders = await XH.portfolioService.generateOrdersAsync(this.orderCount);
             orders.forEach(it => it.maxConfidence = it.minConfidence = it.confidence);
         });
 
@@ -80,6 +86,7 @@ export class CubeDataModel {
         });
 
         await this.executeQueryAsync();
+        this._initialLoadComplete = true;
     }
 
     async executeQueryAsync() {

--- a/client-app/src/mobile/treegrids/TreeGridPageModel.js
+++ b/client-app/src/mobile/treegrids/TreeGridPageModel.js
@@ -78,7 +78,7 @@ export class TreeGridPageModel {
 
     async doLoadAsync(loadSpec) {
         const dims = this.dimensionChooserModel.value;
-        const data = await XH.portfolioService.getPortfolioAsync(dims, 800);
+        const data = await XH.portfolioService.getPortfolioAsync(dims);
         this.gridModel.loadData(data);
     }
 }


### PR DESCRIPTION
+ Use non-blocking whileAsync() util within PortfolioService to generate orders/ref data while allowing UI renders to continue.
+ Remove prior workarounds with one-off delays in service methods.