### PR TITLE
Examples of Grid summary row

### DIFF
--- a/client-app/src/core/svc/PortfolioService.js
+++ b/client-app/src/core/svc/PortfolioService.js
@@ -52,7 +52,7 @@ export class PortfolioService {
 
         return [
             {
-                id: 'rootSummary',
+                id: 'summary',
                 name: 'Total',
                 pnl: round(sumBy(positions, 'pnl')),
                 mktVal: round(sumBy(positions, 'mktVal')),

--- a/client-app/src/core/svc/PortfolioService.js
+++ b/client-app/src/core/svc/PortfolioService.js
@@ -44,7 +44,7 @@ export class PortfolioService {
      * @param {boolean} [includeSummary] - true to include a root summary node
      * @return {Promise<Array>}
      */
-    async getPortfolioAsync(dims, includeSummary) {
+    async getPortfolioAsync(dims, includeSummary = false) {
         await this.ensureLoadedAsync();
         const positions = this.getPositions(castArray(dims));
 

--- a/client-app/src/core/svc/PortfolioService.js
+++ b/client-app/src/core/svc/PortfolioService.js
@@ -48,7 +48,17 @@ export class PortfolioService {
     async getPortfolioAsync(dims, delay = 300) {
         await wait(delay);
         this.ensureLoaded();
-        return this.getPositions(castArray(dims));
+        const positions = this.getPositions(castArray(dims));
+
+        return [
+            {
+                id: 'rootSummary',
+                name: 'Total',
+                pnl: round(sumBy(positions, 'pnl')),
+                mktVal: round(sumBy(positions, 'mktVal')),
+                children: positions
+            }
+        ];
     }
 
     /**

--- a/client-app/src/core/svc/TradeService.js
+++ b/client-app/src/core/svc/TradeService.js
@@ -1,11 +1,11 @@
 import {HoistService} from '@xh/hoist/core';
 import {companyTrades} from '../data/';
-import {cloneDeep} from 'lodash';
+import {cloneDeep, sumBy} from 'lodash';
 
 @HoistService
 export class TradeService {
 
-    generateTrades() {
+    generateTrades(includeSummary) {
         const trades = cloneDeep(companyTrades);
 
         trades.forEach(it => {
@@ -13,6 +13,15 @@ export class TradeService {
             it.trade_volume = it.trade_volume * 1000000;
             it.active = it.trade_volume % 6 == 0;
         });
+
+        if (includeSummary) {
+            trades.push({
+                id: 'summary',
+                profit_loss: sumBy(trades, 'profit_loss'),
+                trade_volume: sumBy(trades, 'trade_volume')
+            });
+        }
+
         return trades;
     }
 

--- a/client-app/src/core/svc/TradeService.js
+++ b/client-app/src/core/svc/TradeService.js
@@ -5,7 +5,7 @@ import {cloneDeep, sumBy} from 'lodash';
 @HoistService
 export class TradeService {
 
-    generateTrades(includeSummary) {
+    generateTrades() {
         const trades = cloneDeep(companyTrades);
 
         trades.forEach(it => {
@@ -14,15 +14,13 @@ export class TradeService {
             it.active = it.trade_volume % 6 == 0;
         });
 
-        if (includeSummary) {
-            trades.push({
+        return {
+            trades,
+            summary: {
                 id: 'summary',
                 profit_loss: sumBy(trades, 'profit_loss'),
                 trade_volume: sumBy(trades, 'trade_volume')
-            });
-        }
-
-        return trades;
+            }
+        };
     }
-
 }

--- a/client-app/src/desktop/common/SampleGrid.js
+++ b/client-app/src/desktop/common/SampleGrid.js
@@ -230,7 +230,8 @@ class Model {
         const gridModel = this.gridModel;
         return wait(250)
             .then(() => {
-                gridModel.loadData(XH.tradeService.generateTrades(true));
+                const {trades, summary} = XH.tradeService.generateTrades();
+                gridModel.loadData(trades, summary);
                 if (!gridModel.hasSelection) gridModel.selectFirst();
             });
     }

--- a/client-app/src/desktop/common/SampleGrid.js
+++ b/client-app/src/desktop/common/SampleGrid.js
@@ -123,6 +123,7 @@ class Model {
 
     @managed
     gridModel = new GridModel({
+        showSummary: 'bottom',
         selModel: {mode: 'multiple'},
         sortBy: 'profit_loss|desc|abs',
         emptyText: 'No records found...',
@@ -229,7 +230,7 @@ class Model {
         const gridModel = this.gridModel;
         return wait(250)
             .then(() => {
-                gridModel.loadData(XH.tradeService.generateTrades());
+                gridModel.loadData(XH.tradeService.generateTrades(true));
                 if (!gridModel.hasSelection) gridModel.selectFirst();
             });
     }

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -14,6 +14,7 @@ import {colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/c
 import {toolbarSep, toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {numberRenderer, millionsRenderer, fmtNumberTooltip} from '@xh/hoist/format';
 import {DimensionChooserModel, dimensionChooser} from '@xh/hoist/desktop/cmp/dimensionchooser';
+import {select} from '@xh/hoist/desktop/cmp/input';
 
 import {gridStyleSwitches} from './GridStyleSwitches';
 
@@ -44,6 +45,17 @@ class SampleTreeGrid extends Component {
             mask: model.loadModel,
             bbar: toolbar(
                 filler(),
+                'Summary',
+                select({
+                    model: gridModel,
+                    bind: 'showSummary',
+                    width: 100,
+                    options: [
+                        {label: 'Top', value: 'top'},
+                        {label: 'Bottom', value: 'bottom'},
+                        {label: 'None', value: false}
+                    ]
+                }),
                 gridStyleSwitches({gridModel})
 
             ),
@@ -71,7 +83,6 @@ class Model {
     @managed
     gridModel = new GridModel({
         treeMode: true,
-        rootSummary: true,
         sortBy: 'pnl|desc|abs',
         emptyText: 'No records found...',
         enableColChooser: true,

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -83,6 +83,9 @@ class Model {
     @managed
     gridModel = new GridModel({
         treeMode: true,
+        store: {
+            treatRootAsSummary: true
+        },
         sortBy: 'pnl|desc|abs',
         emptyText: 'No records found...',
         enableColChooser: true,

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -71,6 +71,7 @@ class Model {
     @managed
     gridModel = new GridModel({
         treeMode: true,
+        rootSummary: true,
         sortBy: 'pnl|desc|abs',
         emptyText: 'No records found...',
         enableColChooser: true,

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -156,7 +156,7 @@ class Model {
             dims = dimChooserModel.value;
 
         return XH.portfolioService
-            .getPortfolioAsync(dims)
+            .getPortfolioAsync(dims, true)
             .then(data => {
                 gridModel.loadData(data);
                 gridModel.selectFirst();

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -84,7 +84,7 @@ class Model {
     gridModel = new GridModel({
         treeMode: true,
         store: {
-            treatRootAsSummary: true
+            loadRootAsSummary: true
         },
         sortBy: 'pnl|desc|abs',
         emptyText: 'No records found...',

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -44,18 +44,17 @@ class SampleTreeGrid extends Component {
             item: grid({model: gridModel}),
             mask: model.loadModel,
             bbar: toolbar(
-                filler(),
-                'Summary',
                 select({
                     model: gridModel,
                     bind: 'showSummary',
-                    width: 100,
+                    width: 150,
                     options: [
-                        {label: 'Top', value: 'top'},
-                        {label: 'Bottom', value: 'bottom'},
-                        {label: 'None', value: false}
+                        {label: 'Top Summary', value: 'top'},
+                        {label: 'Bottom Summary', value: 'bottom'},
+                        {label: 'No Summary', value: false}
                     ]
                 }),
+                filler(),
                 gridStyleSwitches({gridModel})
 
             ),

--- a/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
+++ b/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
@@ -147,6 +147,7 @@ export class CubeDataModel {
     createGridModel() {
         return new GridModel({
             treeMode: true,
+            showSummary: true,
             sortBy: 'time|desc',
             emptyText: 'No records found...',
             enableColChooser: true,

--- a/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
+++ b/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
@@ -156,7 +156,7 @@ export class CubeDataModel {
             treeMode: true,
             showSummary: true,
             store: {
-                treatRootAsSummary: true
+                loadRootAsSummary: true
             },
             sortBy: 'time|desc',
             emptyText: 'No records found...',

--- a/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
+++ b/client-app/src/desktop/tabs/grids/cube/CubeDataModel.js
@@ -155,6 +155,9 @@ export class CubeDataModel {
         return new GridModel({
             treeMode: true,
             showSummary: true,
+            store: {
+                treatRootAsSummary: true
+            },
             sortBy: 'time|desc',
             emptyText: 'No records found...',
             enableColChooser: true,

--- a/client-app/src/mobile/treegrids/TreeGridPageModel.js
+++ b/client-app/src/mobile/treegrids/TreeGridPageModel.js
@@ -31,6 +31,7 @@ export class TreeGridPageModel {
     @managed
     gridModel = new GridModel({
         treeMode: true,
+        showSummary: true,
         enableColChooser: true,
         sortBy: 'pnl|desc|abs',
         columns: [
@@ -78,7 +79,7 @@ export class TreeGridPageModel {
 
     async doLoadAsync(loadSpec) {
         const dims = this.dimensionChooserModel.value;
-        const data = await XH.portfolioService.getPortfolioAsync(dims);
+        const data = await XH.portfolioService.getPortfolioAsync(dims, true);
         this.gridModel.loadData(data);
     }
 }

--- a/client-app/src/mobile/treegrids/TreeGridPageModel.js
+++ b/client-app/src/mobile/treegrids/TreeGridPageModel.js
@@ -32,6 +32,9 @@ export class TreeGridPageModel {
     gridModel = new GridModel({
         treeMode: true,
         showSummary: true,
+        store: {
+            treatRootAsSummary: true
+        },
         enableColChooser: true,
         sortBy: 'pnl|desc|abs',
         columns: [

--- a/client-app/src/mobile/treegrids/TreeGridPageModel.js
+++ b/client-app/src/mobile/treegrids/TreeGridPageModel.js
@@ -33,7 +33,7 @@ export class TreeGridPageModel {
         treeMode: true,
         showSummary: true,
         store: {
-            treatRootAsSummary: true
+            loadRootAsSummary: true
         },
         enableColChooser: true,
         sortBy: 'pnl|desc|abs',


### PR DESCRIPTION
Examples for https://github.com/exhi/hoist-react/pull/1142

Added bottom-pinned summary row for the simple grid example.

Added select to the Tree Grid example to choose location of summary row (top, bottom, none)

For cube example, summary row is configured to appear at the top (only visible when including a root node)