### PR TITLE
Update Toolbox to show off new GridModel.cellBorders

### DIFF
--- a/client-app/src/desktop/common/GridStyleSwitches.js
+++ b/client-app/src/desktop/common/GridStyleSwitches.js
@@ -28,7 +28,14 @@ export class GridStyleSwitches extends Component {
             switchInput({
                 model: gridModel,
                 bind: 'rowBorders',
-                label: 'Borders',
+                label: 'Row Borders',
+                labelAlign: 'left'
+            }),
+            toolbarSep(),
+            switchInput({
+                model: gridModel,
+                bind: 'cellBorders',
+                label: 'Cell Borders',
                 labelAlign: 'left'
             }),
             toolbarSep(),

--- a/client-app/src/desktop/tabs/grids/StandardGridPanel.js
+++ b/client-app/src/desktop/tabs/grids/StandardGridPanel.js
@@ -26,7 +26,7 @@ export class StandardGridPanel extends Component {
             item: panel({
                 title: 'Grids › Standard',
                 icon: Icon.gridPanel(),
-                width: 800,
+                width: 850,
                 height: 400,
                 item: sampleGrid()
             })


### PR DESCRIPTION
See related **Hoist** Issue [#1041](https://github.com/exhi/hoist-react/issues/1041)