### PR TITLE
Use new IsReady prop on AgGridModel

### DIFF
--- a/client-app/src/desktop/tabs/grids/AgGridViewModel.js
+++ b/client-app/src/desktop/tabs/grids/AgGridViewModel.js
@@ -74,11 +74,13 @@ export class AgGridViewModel {
     constructor() {
         const {agGridModel} = this;
         this.addReaction({
-            track: () => [this.data, agGridModel.agApi],
-            run: ([data, api]) => {
-                if (api) api.setRowData(data);
+            track: () => [this.data, agGridModel.isReady],
+            run: ([data, isReady]) => {
+                if (isReady) agGridModel.agApi.setRowData(data);
             }
         });
+
+        if (agGridModel.isReady) agGridModel.getState();
     }
 
     async doLoadAsync() {


### PR DESCRIPTION
Updated the ag-grid wrapper example to use the new IsReady prop instead of checking the agApi reference